### PR TITLE
Migrate to using vorfreude-elixir endpoint

### DIFF
--- a/src/utils/lib/manager/fetcher.ts
+++ b/src/utils/lib/manager/fetcher.ts
@@ -7,7 +7,7 @@ import {
 } from './photos';
 import resizePhotoBlob from './resizePhoto';
 
-const IMAGE_ENDPOINT_URL = 'https://vorfreude-server.herokuapp.com/';
+const IMAGE_ENDPOINT_URL = 'https://vorfreude-elixir.herokuapp.com/api/images';
 
 let indexStorage = new SimpleIndexedDbAdapter('VORFREUDE_PHOTO_STORAGE');
 
@@ -47,7 +47,7 @@ export async function resizePhoto(photo) {
 
 export async function query(searchTerms) {
   let url = new URL(IMAGE_ENDPOINT_URL);
-  url.searchParams.append('searchTerms', searchTerms);
+  url.searchParams.append('search', searchTerms);
 
   let result = await window.fetch(url.toString());
   let photos = (await result.json()).photos.photo;


### PR DESCRIPTION
The existing flickr proxy server used ([chadian/vorfreude-server](https://github.com/chadian/vorfreude-server)) has been replaced with an elixir implementation([chadian/vorfreude-server-elixir](https://github.com/chadian/vorfreude-server-elixir)).  This was basically done just to improve my understanding and experience with elixir. After some time the existing service will be shut down.