### PR TITLE
Hide empty time segments

### DIFF
--- a/src/ui/components/CountdownTimer/template.hbs
+++ b/src/ui/components/CountdownTimer/template.hbs
@@ -1,19 +1,27 @@
 <div class="CountdownTimer">
   {{#if time}}
     <div class="CountdownTimer__segment">
-      {{time.days}} {{plural-rules time.days 'days'}}
+      {{#unless (eq time.days undefined)}}
+        {{time.days}} {{plural-rules time.days 'days'}}
+      {{/unless}}
     </div>
-  
+    
     <div class="CountdownTimer__segment">
-      {{time.hours}} {{plural-rules time.hours 'hours'}}
+      {{#unless (eq time.hours undefined)}}
+        {{time.hours}} {{plural-rules time.hours 'hours'}}
+      {{/unless}}
     </div>
 
     <div class="CountdownTimer__segment">
-      {{time.minutes}} {{plural-rules time.minutes 'minutes'}}
+      {{#unless (eq time.minutes undefined)}}
+        {{time.minutes}} {{plural-rules time.minutes 'minutes'}}
+      {{/unless}}
     </div>
 
     <div class="CountdownTimer__segment">
+      {{#unless (eq time.seconds undefined)}}
         {{time.seconds}} {{plural-rules time.seconds 'seconds'}}
+      {{/unless}}
     </div>
   {{/if}}
 </div>


### PR DESCRIPTION
Previously the template would hide empty segments and this pull request brings this back to fix this bug:
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/2770198/170567097-deadbc26-02a7-4ff5-907f-e9ca8d203fd2.png">

where the countdown is less than an hour away but the *days* and *hours* label still shows up.