### PR TITLE
Improve the order of operations around the photo store and manager

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,16 +1,20 @@
 <script>
   import '../global.css';
   import Wallpaper from '../components/Wallpaper.svelte';
-  import { currentPhoto, performPhotoHouseKeeping } from '../state/stores/photo';
+  import { setup as setupPhotoStore, currentPhoto, performPhotoHouseKeeping } from '../state/stores/photo';
   import { onMount } from 'svelte';
-  import { afterNavigate, goto } from '$app/navigation';
+  import { afterNavigate } from '$app/navigation';
   import { handleInitialHashRoute, handleRouteChange } from '../helpers/hash-routes';
 
   export const prerender = true
 
-  onMount(() => {
-    handleInitialHashRoute();
-    performPhotoHouseKeeping();
+  onMount(async () => {
+    await Promise.all([
+      handleInitialHashRoute(),
+      setupPhotoStore()
+    ]);
+
+    await performPhotoHouseKeeping();
   });
 
   afterNavigate(() => {

--- a/src/state/stores/photo.ts
+++ b/src/state/stores/photo.ts
@@ -1,19 +1,42 @@
 import { writable } from 'svelte/store';
 import Manager from '../../photo-manager/manager';
 import { getSettingsStore } from './settings';
-export const currentPhoto = writable({ blur: false, url: '' });
+import { get } from 'svelte/store';
 
-const manager = new Manager();
+export const currentPhoto = writable({ blur: false, url: '' });
 const isBrowser = typeof window !== 'undefined';
 
+let manager;
+
+export async function setup() {
+  manager = new Manager();
+
+  if (!isBrowser) {
+    return;
+  }
+
+  const settingsStore = await getSettingsStore();
+  const { searchTerms: initialSearchTerms } = get(settingsStore);
+  await updateCurrentPhoto(initialSearchTerms);
+
+  settingsStore.subscribe(async (settings) => {
+    const { searchTerms } = settings;
+    await updateCurrentPhoto(searchTerms);
+  });
+}
+
 export async function performPhotoHouseKeeping() {
+  if (!manager) {
+    throw new Error('Store must be setup first, ensure `setup` has been called');
+  }
+
   if (isBrowser) {
-    await manager.checkAndReplenishBacklog();
+    await manager.replenishBacklog();
     await Promise.all([manager.removeStalePhotoBlobs(), manager.removeOldPhotos()]);
   }
 }
 
-async function setPhoto(searchTerms) {
+async function updateCurrentPhoto(searchTerms) {
   if (!searchTerms) {
     return;
   }
@@ -28,17 +51,3 @@ async function setPhoto(searchTerms) {
     };
   });
 }
-
-async function load() {
-  if (!isBrowser) {
-    return;
-  }
-
-  const settingsStore = await getSettingsStore();
-  settingsStore.subscribe((settings) => {
-    const { searchTerms } = settings;
-    setPhoto(searchTerms);
-  });
-}
-
-load();


### PR DESCRIPTION
The root `+layout.svelte` was previously calling for the housekeeping tasks including replenish the backlog before the store had properly loaded the manager with the appropriate search terms.

Now the `setup` is called explicitly with the current search terms from the settings store and subscribing to all future updates. This should ensure that the manager is setup along side the store.

`performPhotoHouseKeeping` also makes sure that the manager has been created via `setup` before allowing any housekeeping otherwise throwing an error.

Lastly, the root +layout calls `setup` and then once that has finished it calls `performPhotoHouseKeeping`.

Fixes #36.
This also appears to fix the bug in firefox where searchTerms being sent via message to `background.js` from `replenishBacklog` was an empty string.