### PR TITLE
Fix double-load of images

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,12 +9,14 @@
   export const prerender = true
 
   onMount(async () => {
-    await Promise.all([
-      handleInitialHashRoute(),
-      setupPhotoStore()
+    const [teardownPhotoStore] = await Promise.all([
+      setupPhotoStore(),
+      handleInitialHashRoute()
     ]);
 
     await performPhotoHouseKeeping();
+
+    return () => teardownPhotoStore();
   });
 
   afterNavigate(() => {

--- a/src/state/stores/photo.ts
+++ b/src/state/stores/photo.ts
@@ -1,7 +1,6 @@
 import { writable } from 'svelte/store';
 import Manager from '../../photo-manager/manager';
 import { getSettingsStore } from './settings';
-import { get } from 'svelte/store';
 
 export const currentPhoto = writable({ blur: false, url: '' });
 const isBrowser = typeof window !== 'undefined';
@@ -9,20 +8,22 @@ const isBrowser = typeof window !== 'undefined';
 let manager;
 
 export async function setup() {
-  manager = new Manager();
-
   if (!isBrowser) {
     return;
   }
 
-  const settingsStore = await getSettingsStore();
-  const { searchTerms: initialSearchTerms } = get(settingsStore);
-  await updateCurrentPhoto(initialSearchTerms);
+  if (!manager) {
+    manager = new Manager();
+  }
 
-  settingsStore.subscribe(async (settings) => {
+  const settingsStore = await getSettingsStore();
+
+  const unsubscribeSettingsStore = settingsStore.subscribe(async (settings) => {
     const { searchTerms } = settings;
     await updateCurrentPhoto(searchTerms);
   });
+
+  return () => unsubscribeSettingsStore();
 }
 
 export async function performPhotoHouseKeeping() {


### PR DESCRIPTION
The fn arg passed to `subscribe` from a svelte store will be called immediately, and then also for subsequent updates.

Previously, in the photos store I was retrieving an initial value, calling `updateCurrentPhoto` and then also picking up an additional initial value from subscribe calling `updateCurrentPhoto` creating  double images being loaded with the first one appearing as a quick flash before the second one would come in.

This pull request removes the unnecessary first `updateCurrentPhoto` since `subscribe` can be reliably used for initial calls.