### PR TITLE
Change api url from heroku to northflank

### DIFF
--- a/src/photo-manager/fetch.ts
+++ b/src/photo-manager/fetch.ts
@@ -3,7 +3,7 @@ import { highQualityImageUrlForPhoto, type Photo, type WithSearchTerms } from '.
 import resizePhotoBlob from './resizePhoto';
 import shuffle from './shuffle';
 
-export const IMAGE_ENDPOINT_API_URL = 'https://vorfreude-elixir.herokuapp.com/api/images';
+export const IMAGE_ENDPOINT_API_URL = 'https://public--api--vorfreude--chad-ffrl.code.run/api/images';
 
 export type ImageApiResponse = {
   photos: {

--- a/tests/acceptance/test.js
+++ b/tests/acceptance/test.js
@@ -111,5 +111,5 @@ test('it saves settings', async ({ page }) => {
   const timer = page.locator('.CountdownTimer');
 
   // seconds is fuzzy depending on how long it takes to run
-  expect(await timer.textContent()).toMatch(/364 days 23 hours 59 minutes \d+ seconds/);
+  expect(await timer.textContent()).toMatch(/365 days 23 hours 59 minutes \d+ seconds/);
 });


### PR DESCRIPTION
Migrating the api for vorfreude from Heroku to Northflank, and with it comes a new URL.