### PR TITLE
Add feature to block photos from reappearing

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/chrome": "^0.0.196",
     "@types/luxon": "^3.0.1",
+    "@types/ramda": "^0.29.0",
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
     "babel-jest": "^29.0.2",

--- a/package.json
+++ b/package.json
@@ -64,5 +64,9 @@
     "typescript": "~4.8.3",
     "vite": "^3.1.0"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "@types/debug": "^4.1.7",
+    "debug": "^4.3.4"
+  }
 }

--- a/src/background-operation.ts
+++ b/src/background-operation.ts
@@ -1,0 +1,3 @@
+export const BackgroundOperation = {
+  REPLENISH_BACKLOG: 'replenishBacklog',
+};

--- a/src/chrome/background.ts
+++ b/src/chrome/background.ts
@@ -1,9 +1,6 @@
+import { BackgroundOperation } from '../background-operation';
 import isExtensionEnv from '../helpers/isExtensionEnv';
 import { Replenisher } from '../photo-manager/replenisher'
-
-export const BackgroundOperation = {
-  REPLENISH_BACKLOG: 'replenishBacklog',
-};
 
 function openVorfreudeTab() {
   const vorfreudeUrl = chrome.extension.getURL('index.html');

--- a/src/chrome/background.ts
+++ b/src/chrome/background.ts
@@ -1,18 +1,24 @@
+import isExtensionEnv from '../helpers/isExtensionEnv';
 import { Replenisher } from '../photo-manager/replenisher'
 
-chrome.runtime.onMessage.addListener(function(message) {
-  if (message.operation === 'replenishBacklog') {
-    const { searchTerms, downloadBatchSize } = message;
-
-    const replenisher = new Replenisher(searchTerms);
-    replenisher.downloadBatchSize = downloadBatchSize;
-    replenisher.replenish();
-  }
-});
+export const BackgroundOperation = {
+  REPLENISH_BACKLOG: 'replenishBacklog',
+};
 
 function openVorfreudeTab() {
   const vorfreudeUrl = chrome.extension.getURL('index.html');
   chrome.tabs.create({ url: vorfreudeUrl });
 }
 
-chrome.browserAction.onClicked.addListener(() => openVorfreudeTab());
+if (isExtensionEnv()) {
+  chrome.runtime.onMessage.addListener(function(message) {
+    if (message.operation === BackgroundOperation.REPLENISH_BACKLOG) {
+      const { searchTerms, downloadBatchSize } = message;
+      const replenisher = new Replenisher(searchTerms);
+      replenisher.downloadBatchSize = downloadBatchSize;
+      replenisher.replenish();
+    }
+  });
+  
+  chrome.browserAction.onClicked.addListener(() => openVorfreudeTab());
+}

--- a/src/components/BlockButton.svelte
+++ b/src/components/BlockButton.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  type onSettingsButtonClick = () => void;
+  export let onClick: onSettingsButtonClick = () => {};
+</script>
+
+<button class="Vorfreude__show-settings" on:click={() => onClick()}>
+  <span class="Vorfreude__show-settings-symbol">
+    <svg width="28" height="28" xmlns="http://www.w3.org/2000/svg" viewBox="-144 -144 288 288">
+      <path
+        fill="white"
+        d="M-101.116-101.116a143 143 0 1 1 202.232 202.232 143 143 0 0 1-202.232-202.232M-68.59 89.803A113 113 0 0 0 89.803-68.59zM68.589-89.803A113 113 0 0 0-89.803 68.59z"
+      />
+    </svg>
+  </span>
+</button>
+
+<style>
+  .Vorfreude__show-settings {
+    cursor: pointer;
+    width: 25px;
+    height: 25px;
+    background: none;
+    border: none;
+    padding: 0;
+  }
+
+  @media only screen and (max-width: 425px) {
+    .Vorfreude__show-settings {
+      width: 28px;
+      height: 28px;
+    }
+  }
+
+  .Vorfreude__show-settings-symbol {
+    position: relative;
+    bottom: -2px;
+  }
+</style>

--- a/src/components/SettingsButton.svelte
+++ b/src/components/SettingsButton.svelte
@@ -17,10 +17,11 @@
 <style>
   .Vorfreude__show-settings {
     cursor: pointer;
-    width: 45px;
-    height: 45px;
+    width: 30px;
+    height: 30px;
     background: none;
     border: none;
+    padding: 0;
   }
 
   @media only screen and (max-width: 425px) {

--- a/src/helpers/isExtensionEnv.ts
+++ b/src/helpers/isExtensionEnv.ts
@@ -3,5 +3,5 @@ type ChromeExtensionWindow = typeof window & {
 };
 
 export default function () {
-  return Boolean((globalThis as ChromeExtensionWindow)?.chrome?.windows);
+  return Boolean((globalThis as ChromeExtensionWindow)?.chrome?.runtime);
 }

--- a/src/photo-manager/cleaner.ts
+++ b/src/photo-manager/cleaner.ts
@@ -1,4 +1,4 @@
-import { storePhoto, retrieveAllPhotos, removePhoto, filterBlockedPhotos } from "./photos";
+import { storePhoto, retrieveAllPhotos, removePhoto, photoIsBlocked } from "./photos";
 
 export const cleanDownloadFromPhoto = (photo) => {
   photo.blob = null;
@@ -7,7 +7,7 @@ export const cleanDownloadFromPhoto = (photo) => {
 
 export const cleanUnblockedPhotosWithoutGivenSearchTerms = async (searchTerms) => {
   const photos = await retrieveAllPhotos();
-  const photosToKeep = filterBlockedPhotos(photos);
+  const photosToKeep = photos.filter(photoIsBlocked);
   const photosToRemove = photos.filter((photo) => photo.searchTerms !== searchTerms && !photosToKeep.includes(photo));
   
   photosToRemove.forEach((photo) => removePhoto(photo));

--- a/src/photo-manager/cleaner.ts
+++ b/src/photo-manager/cleaner.ts
@@ -1,12 +1,14 @@
-import { storePhoto, retrieveAllPhotos, removePhoto } from "./photos";
+import { storePhoto, retrieveAllPhotos, removePhoto, filterBlockedPhotos } from "./photos";
 
 export const cleanDownloadFromPhoto = (photo) => {
   photo.blob = null;
   storePhoto(photo);
 };
 
-export const cleanPhotosWithoutGivenSearchTerms = async (searchTerms) => {
+export const cleanUnblockedPhotosWithoutGivenSearchTerms = async (searchTerms) => {
   const photos = await retrieveAllPhotos();
-  const photosToRemove = photos.filter((photo) => photo.searchTerms !== searchTerms);
+  const photosToKeep = filterBlockedPhotos(photos);
+  const photosToRemove = photos.filter((photo) => photo.searchTerms !== searchTerms && !photosToKeep.includes(photo));
+  
   photosToRemove.forEach((photo) => removePhoto(photo));
 };

--- a/src/photo-manager/fetch.ts
+++ b/src/photo-manager/fetch.ts
@@ -1,7 +1,7 @@
 import { clone } from 'ramda';
 import { highQualityImageUrlForPhoto } from './photos';
 import resizePhotoBlob from './resizePhoto';
-import type { Photo, WithSearchTerms } from './types';
+import type { Photo, WithBlob, WithSearchTerms } from './types';
 
 export const IMAGE_ENDPOINT_API_URL = 'https://web-production-be97.up.railway.app/api/images';
 
@@ -11,12 +11,13 @@ export type ImageApiResponse = {
   }
 };
 
-export function fetchPhotosBlobs(photos: Photo[]) {
+export function fetchPhotosBlobs<T extends Photo>(photos: T[]): Promise<(Photo & WithBlob)[]> {
   photos = clone(photos);
 
   return Promise.all(
     photos.map(async (photo: Photo) => {
       const url = highQualityImageUrlForPhoto(photo);
+
       return fetch(url)
         .then((response) => response?.blob())
         .then((blob) => {

--- a/src/photo-manager/fetch.ts
+++ b/src/photo-manager/fetch.ts
@@ -1,7 +1,7 @@
-import { clone, take } from 'ramda';
-import { highQualityImageUrlForPhoto, type Photo, type WithSearchTerms } from './photos';
+import { clone } from 'ramda';
+import { highQualityImageUrlForPhoto } from './photos';
 import resizePhotoBlob from './resizePhoto';
-import shuffle from './shuffle';
+import type { Photo, WithSearchTerms } from './types';
 
 export const IMAGE_ENDPOINT_API_URL = 'https://web-production-be97.up.railway.app/api/images';
 
@@ -11,7 +11,7 @@ export type ImageApiResponse = {
   }
 };
 
-export function fetchPhotos(photos: Photo[]) {
+export function fetchPhotosBlobs(photos: Photo[]) {
   photos = clone(photos);
 
   return Promise.all(
@@ -51,11 +51,4 @@ export async function query(searchTerms): Promise<(Photo & WithSearchTerms)[]> {
         searchTerms: searchTerms
       };
     });
-}
-
-export async function fetchPopularPhotoUrl(searchTerms) {
-  const photos = await query(searchTerms);
-  const photoUrls = photos.map(highQualityImageUrlForPhoto);
-
-  return take(50, shuffle(photoUrls)).pop();
 }

--- a/src/photo-manager/fetch.ts
+++ b/src/photo-manager/fetch.ts
@@ -1,7 +1,7 @@
 import { clone } from 'ramda';
 import { highQualityImageUrlForPhoto } from './photos';
 import resizePhotoBlob from './resizePhoto';
-import type { Photo, WithBlob, WithSearchTerms } from './types';
+import type { Photo, WithOptionalBlob, WithSearchTerms } from './types';
 
 export const IMAGE_ENDPOINT_API_URL = 'https://web-production-be97.up.railway.app/api/images';
 
@@ -11,7 +11,7 @@ export type ImageApiResponse = {
   }
 };
 
-export function fetchPhotosBlobs<T extends Photo>(photos: T[]): Promise<(Photo & WithBlob)[]> {
+export function fetchPhotosBlobs<T extends Photo>(photos: T[]): Promise<(Photo & WithOptionalBlob)[]> {
   photos = clone(photos);
 
   return Promise.all(

--- a/src/photo-manager/manager.test.ts
+++ b/src/photo-manager/manager.test.ts
@@ -1,0 +1,80 @@
+import Manager from './manager';
+import type { Photo, WithOptionalBlob, WithSearchTerms } from './types';
+
+function createPhoto<T>(photoPartial: Partial<Photo> & T): Photo & T {
+  const id = photoPartial.id ?? Math.round(Math.random() * 1_000_000).toString();
+
+  return {
+    id,
+    isBlocked: false,
+    url_o: `https://flickr-test-url/download/${id}`,
+
+    ...photoPartial,
+  };
+}
+
+describe('Manager', () => {
+  let manager;
+
+  beforeEach(() => {
+    manager = new Manager();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('#getDisplayablePhotoCandidates filters photos with blobs', async () => {
+    const storedPhotos = [
+      createPhoto<WithSearchTerms & WithOptionalBlob>({ searchTerms: 'New York City', blob: new Blob() }),
+      createPhoto<WithSearchTerms & WithOptionalBlob>({ searchTerms: 'New York City', blob: undefined }),
+      createPhoto<WithSearchTerms & WithOptionalBlob>({ searchTerms: 'New York City', blob: new Blob() }),
+    ];
+
+    jest.spyOn(manager, 'getSearchTermPhotos').mockResolvedValueOnce(storedPhotos);
+    const result = await manager.getDisplayablePhotoCandidates();
+
+    const expectedNumberOfPhotosWithBlobs = 2;
+    expect(storedPhotos.filter(photo => photo.blob).length).toEqual(expectedNumberOfPhotosWithBlobs);
+    expect(result.length).toEqual(expectedNumberOfPhotosWithBlobs);
+  });
+
+  test('#getDisplayablePhotoCandidates filters out blocked photos', async () => {
+    const storedPhotos = [
+      createPhoto<WithSearchTerms & WithOptionalBlob>({ searchTerms: 'New York City', isBlocked: true, blob: new Blob() }),
+      createPhoto<WithSearchTerms & WithOptionalBlob>({ searchTerms: 'New York City', isBlocked: true, blob: new Blob() }),
+      createPhoto<WithSearchTerms & WithOptionalBlob>({ searchTerms: 'New York City', blob: new Blob() }),
+    ];
+
+    jest.spyOn(manager, 'getSearchTermPhotos').mockResolvedValueOnce(storedPhotos);
+    const result = await manager.getDisplayablePhotoCandidates();
+
+    const expectedNumberOfBlockedPhotos = 2;
+    expect(storedPhotos.filter(photo => photo.isBlocked).length).toEqual(expectedNumberOfBlockedPhotos);
+
+    const expectedNumberOfUnblockedPhotos = storedPhotos.length - expectedNumberOfBlockedPhotos;
+    expect(result.length).toEqual(expectedNumberOfUnblockedPhotos);
+  });
+
+  test('#getDisplayablePhoto fetches photos when no photos are available', async () => {
+    jest.spyOn(manager, 'startReplenishBacklog').mockResolvedValue(undefined);
+
+    const mockPhoto = createPhoto<WithSearchTerms & WithOptionalBlob>({ searchTerms: 'New York City', blob: new Blob() });
+    // mimic an empty photo store with multiple checks, forcing multiple retries,
+    // finally resolving with photos
+    jest.spyOn(manager, 'getSearchTermPhotos')
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([
+        mockPhoto
+      ]);
+
+    expect(await manager.getDisplayablePhoto()).toEqual(mockPhoto);
+    expect(manager.startReplenishBacklog).toHaveBeenCalledTimes(1);
+
+    // retries: +3 empty photo stores, +1 with photos
+    // +1 get photos and pick one to display
+    expect(manager.getSearchTermPhotos).toHaveBeenCalledTimes(5);
+  });
+});

--- a/src/photo-manager/manager.ts
+++ b/src/photo-manager/manager.ts
@@ -1,58 +1,94 @@
-import { take } from 'ramda';
+import { take, pipe } from 'ramda';
 import {
+  filterBlockedPhotos,
   filterPhotosForSearchTerms,
-  isPhotoStale,
+  markPhotoAsBlocked,
   markPhotoAsSeen,
   photoHasDownload,
   retrieveAllPhotos,
   shouldDownloadPhotos,
-  storePhoto
+  storePhoto,
 } from './photos';
 
-import { cleanDownloadFromPhoto, cleanPhotosWithoutGivenSearchTerms } from './cleaner';
+import { cleanDownloadFromPhoto, cleanUnblockedPhotosWithoutGivenSearchTerms } from './cleaner';
 import shuffle from './shuffle';
-import { fetchPopularPhotoUrl } from './fetch';
 import isExtensionEnv from '../helpers/isExtensionEnv';
 import { Replenisher } from './replenisher';
+import type { Photo, WithBlob, WithSeenCount } from './types';
 
-const BATCH_SIZE = 3;
+const DOWNLOAD_BATCH_SIZE = 3;
+const DELETE_STALE_BATCH_SIZE = 3;
 
 export default class Manager {
-  public static urlForBlob = (blob) => URL.createObjectURL(blob);
+  private _searchTerms = '';
 
-  private searchTerms = '';
-  private replenisher: Replenisher;
+  get searchTerms() {
+    return this._searchTerms;
+  }
 
   setSearchTerms(newSearchTerms) {
     // set new
-    this.searchTerms = newSearchTerms;
-    this.replenisher = new Replenisher(newSearchTerms);
-
+    this._searchTerms = newSearchTerms;
     this.removeOldPhotos();
   }
 
-  async getPhotos() {
-    const allPhotos = await retrieveAllPhotos();
-    const filteredPhotos = filterPhotosForSearchTerms(allPhotos, this.searchTerms);
-    return filteredPhotos;
+  async getSearchTermPhotos() {
+    const filteredPhotos = pipe(
+      async () => retrieveAllPhotos(),
+      async (photos) => filterPhotosForSearchTerms(await photos, this.searchTerms),
+    );
+
+    return (await filteredPhotos()) ?? [];
   }
 
-  async getPhoto() {
-    const downloadedPhotos = (await this.getPhotos()).filter(photoHasDownload);
+  async getDisplayablePhotoCandidates(): Promise<(Photo & WithSeenCount & WithBlob)[]> {
+    const candidates = await pipe(
+      async () => this.getSearchTermPhotos(),
+      async (photos) => (await photos).filter(photoHasDownload),
+      async (photos) => filterBlockedPhotos(await photos)
+    )();
 
-    // no photos downloaded, go get one directly
-    if (downloadedPhotos.length === 0) {
-      const photoUrl = await fetchPopularPhotoUrl(this.searchTerms);
-      return photoUrl;
+    return candidates;
+  }
+
+  async getDisplayablePhoto() {
+    // no photos available
+    // we rely on the backlog to be replenished in the future, but it's possible:
+    // 1. The photo has just changed the search terms
+    // 2. The user has just blocked all photos
+    // 3. The manager has cleaned old photos and is in the process of getting new ones
+    await this.waitForBacklog();
+
+    const displayablePhotos = await this.getDisplayablePhotoCandidates();
+    const photo = shuffle(displayablePhotos).pop();
+    this.markPhotoAsSeen(photo);
+
+    return photo;
+  }
+
+  async waitForBacklog(retries = 10) {
+    const retryTimeout = 500;
+    console.log('waiting for backlog', retries);
+
+    if (retries === 0) {
+      throw new Error('Unable to replenish backlog');
     }
 
-    const photo = shuffle(downloadedPhotos).pop();
-    this.markPhotoAsSeen(photo);
-    return Manager.urlForBlob(photo.blob);
+    await this.replenishBacklog();
+    const candidates = await this.getDisplayablePhotoCandidates();
+
+    if (candidates.length > 0) {
+      return;
+    }
+
+    const wait = new Promise((resolve) => setTimeout(resolve, retryTimeout));
+    await wait;
+
+    await this.waitForBacklog(retries--);
   }
 
   async replenishBacklog() {
-    const photos = await this.getPhotos();
+    const photos = await this.getSearchTermPhotos();
 
     if (!shouldDownloadPhotos(photos)) {
       return;
@@ -61,22 +97,35 @@ export default class Manager {
     if (isExtensionEnv()) {
       chrome.runtime.sendMessage({
         operation: 'replenishBacklog',
-        downloadBatchSize: BATCH_SIZE,
+        downloadBatchSize: DOWNLOAD_BATCH_SIZE,
         searchTerms: this.searchTerms
       });
     } else {
-      this.replenisher?.replenish();
+      const replenisher = new Replenisher(this.searchTerms);
+      replenisher.replenish();
     }
   }
 
   async removeStalePhotoBlobs() {
-    const photos = await this.getPhotos();
-    const stalePhotos = photos.filter(isPhotoStale);
-    take(BATCH_SIZE, stalePhotos).forEach(cleanDownloadFromPhoto);
+    const photos = (await this.getSearchTermPhotos());
+    const stalePhotos = photos.filter(photoHasDownload);
+    take(DELETE_STALE_BATCH_SIZE, stalePhotos).forEach(cleanDownloadFromPhoto);
+  }
+
+  async blockPhoto(photo: Photo) {
+    markPhotoAsBlocked(photo);
+    storePhoto(photo);
+    await this.removeBlockedPhotoBlobs();
   }
 
   async removeOldPhotos() {
-    cleanPhotosWithoutGivenSearchTerms(this.searchTerms);
+    cleanUnblockedPhotosWithoutGivenSearchTerms(this.searchTerms);
+  }
+
+  private async removeBlockedPhotoBlobs() {
+    const photos = await this.getSearchTermPhotos();
+    const blockedPhotosWithBlobs = filterBlockedPhotos(photos).filter(photoHasDownload);
+    blockedPhotosWithBlobs.forEach(cleanDownloadFromPhoto);
   }
 
   private markPhotoAsSeen(photo) {

--- a/src/photo-manager/manager.ts
+++ b/src/photo-manager/manager.ts
@@ -17,9 +17,11 @@ import isExtensionEnv from '../helpers/isExtensionEnv';
 import { Replenisher } from './replenisher';
 import type { Photo, WithOptionalBlob, WithSeenCount } from './types';
 import { BackgroundOperation } from '../background-operation';
+import Debug from 'debug';
 
 const DOWNLOAD_BATCH_SIZE = 3;
 const DELETE_STALE_BATCH_SIZE = 3;
+const debug = Debug('manager');
 
 export default class Manager {
   private _searchTerms = '';
@@ -54,7 +56,7 @@ export default class Manager {
 
   async getDisplayablePhoto() {
     let displayablePhotos = await this.getDisplayablePhotoCandidates();
-    console.log(`getDisplayablePhoto: found ${displayablePhotos.length} photos to display`);
+    debug(`getDisplayablePhoto: found ${displayablePhotos.length} photos to display`);
 
     // we rely on the backlog to be replenished but it's possible:
     // 1. The photo has just changed the search terms
@@ -77,7 +79,7 @@ export default class Manager {
 
   async waitForBacklog(retries = 40) {
     const retryTimeoutMs = 250;
-    console.log(`waitForBacklog: waiting for backlog, ${retries} retries remaining`);
+    debug(`waitForBacklog: waiting for backlog, ${retries} retries remaining`);
 
     if (retries === 0) {
       throw new Error('Unable to replenish backlog');
@@ -86,7 +88,7 @@ export default class Manager {
     const candidates = await this.getDisplayablePhotoCandidates();
 
     if (candidates.length > 0) {
-      console.log('waitForBacklog: found candidates, exiting', candidates);
+      debug('waitForBacklog: found candidates, exiting', candidates);
       return;
     }
 
@@ -102,7 +104,7 @@ export default class Manager {
   }
 
   async startReplenishBacklog() {
-    console.log('replenishBacklog: kicking off backlog replenish');
+    debug('replenishBacklog: kicking off backlog replenish');
 
     if (isExtensionEnv()) {
       chrome.runtime.sendMessage({
@@ -118,7 +120,7 @@ export default class Manager {
       replenisher.replenish();
     }
 
-    console.log('replenishBacklog: finished backlog replenish');
+    debug('replenishBacklog: finished backlog replenish');
   }
 
   async removeStalePhotoBlobs() {

--- a/src/photo-manager/manager.ts
+++ b/src/photo-manager/manager.ts
@@ -54,7 +54,7 @@ export default class Manager {
 
   async getDisplayablePhoto() {
     let displayablePhotos = await this.getDisplayablePhotoCandidates();
-    console.log({ displayablePhotos });
+    console.log(`getDisplayablePhoto: found ${displayablePhotos.length} photos to display`);
 
     // we rely on the backlog to be replenished in the future, but it's possible:
     // 1. The photo has just changed the search terms
@@ -86,7 +86,7 @@ export default class Manager {
     const candidates = await this.getDisplayablePhotoCandidates();
 
     if (candidates.length > 0) {
-      console.log('found candidates, we are good to go', candidates);
+      console.log('waitForBacklog: found candidates, exiting', candidates);
       return;
     }
 
@@ -97,13 +97,12 @@ export default class Manager {
   }
 
   async startReplenishBacklog() {
-    console.log('replenishBacklog: kicking off backlog replenish');
     const photos = await this.getSearchTermPhotos();
 
     if (!shouldDownloadPhotos(photos)) {
-      console.log('startReplenishBacklog: should not download photos');
       return;
     }
+    console.log('replenishBacklog: kicking off backlog replenish');
 
     if (isExtensionEnv()) {
       chrome.runtime.sendMessage({
@@ -118,6 +117,8 @@ export default class Manager {
       // `sendMessage` implementation
       replenisher.replenish();
     }
+
+    console.log('replenishBacklog: finished backlog replenish');
   }
 
   async removeStalePhotoBlobs() {

--- a/src/photo-manager/manager.ts
+++ b/src/photo-manager/manager.ts
@@ -60,7 +60,7 @@ export default class Manager {
     // 1. The photo has just changed the search terms
     // 2. The user has just blocked all photos
     // 3. The manager has cleaned old photos and is in the process of getting new ones
-    if (!displayablePhotos?.length) {
+    if (!displayablePhotos?.length && await this.shouldReplenishBacklog()) {
       // kick off at least one backlog replenish to wait for
       await this.startReplenishBacklog();
 
@@ -96,12 +96,12 @@ export default class Manager {
     await this.waitForBacklog(--retries);
   }
 
-  async startReplenishBacklog() {
+  async shouldReplenishBacklog() {
     const photos = await this.getSearchTermPhotos();
+    return shouldDownloadPhotos(photos);
+  }
 
-    if (!shouldDownloadPhotos(photos)) {
-      return;
-    }
+  async startReplenishBacklog() {
     console.log('replenishBacklog: kicking off backlog replenish');
 
     if (isExtensionEnv()) {

--- a/src/photo-manager/manager.ts
+++ b/src/photo-manager/manager.ts
@@ -15,8 +15,7 @@ import { cleanDownloadFromPhoto, cleanUnblockedPhotosWithoutGivenSearchTerms } f
 import shuffle from './shuffle';
 import isExtensionEnv from '../helpers/isExtensionEnv';
 import { Replenisher } from './replenisher';
-import type { Photo, WithBlob, WithSeenCount } from './types';
-import { BackgroundOperation } from 'src/background-operation';
+import type { Photo, WithOptionalBlob, WithSeenCount } from './types';
 import { BackgroundOperation } from '../background-operation';
 
 const DOWNLOAD_BATCH_SIZE = 3;
@@ -43,7 +42,7 @@ export default class Manager {
     return (await filteredPhotos()) ?? [];
   }
 
-  async getDisplayablePhotoCandidates(): Promise<(Photo & WithSeenCount & WithBlob)[]> {
+  async getDisplayablePhotoCandidates(): Promise<(Photo & WithSeenCount & WithOptionalBlob)[]> {
     const candidates = await pipe(
       async () => this.getSearchTermPhotos(),
       async (photos) => (await photos).filter(photoHasDownload),

--- a/src/photo-manager/manager.ts
+++ b/src/photo-manager/manager.ts
@@ -56,9 +56,9 @@ export default class Manager {
     let displayablePhotos = await this.getDisplayablePhotoCandidates();
     console.log(`getDisplayablePhoto: found ${displayablePhotos.length} photos to display`);
 
-    // we rely on the backlog to be replenished in the future, but it's possible:
+    // we rely on the backlog to be replenished but it's possible:
     // 1. The photo has just changed the search terms
-    // 2. The user has just blocked all photos
+    // 2. The user has blocked the remaining photos
     // 3. The manager has cleaned old photos and is in the process of getting new ones
     if (!displayablePhotos?.length && await this.shouldReplenishBacklog()) {
       // kick off at least one backlog replenish to wait for

--- a/src/photo-manager/manager.ts
+++ b/src/photo-manager/manager.ts
@@ -16,7 +16,8 @@ import shuffle from './shuffle';
 import isExtensionEnv from '../helpers/isExtensionEnv';
 import { Replenisher } from './replenisher';
 import type { Photo, WithBlob, WithSeenCount } from './types';
-import { BackgroundOperation } from '../chrome/background';
+import { BackgroundOperation } from 'src/background-operation';
+import { BackgroundOperation } from '../background-operation';
 
 const DOWNLOAD_BATCH_SIZE = 3;
 const DELETE_STALE_BATCH_SIZE = 3;

--- a/src/photo-manager/photos.ts
+++ b/src/photo-manager/photos.ts
@@ -2,8 +2,8 @@ import { photoStorage } from "../state/storage/photo";
 import type { Photo, WithBlob, WithSearchTerms, WithSeenCount } from "./types";
 
 const STALE_SEEN_COUNT = 3;
-const MINIMINUM_FRESH_PERCENTAGE = 25;
 const MAX_TOTAL_DOWNLOADED = 20;
+const MIN_FRESH_PERCENTAGE = 25;
 
 export function photoHasDownload<T>(photo: T): photo is T & WithBlob {
   if (typeof photo === 'object' && photo && 'blob' in photo && photo.blob instanceof Blob) {
@@ -13,18 +13,18 @@ export function photoHasDownload<T>(photo: T): photo is T & WithBlob {
   return false;
 }
 
-// export const photoHasDownload = (photo: T)<T>: photo is T & WithBlob  => Boolean(photo?.blob);
 export const isPhotoStale = (photo: Photo & WithBlob & WithSeenCount) => photo.blob && photo.seenCount > STALE_SEEN_COUNT;
+export const photoIsBlocked = (photo: Photo) => Boolean(photo.isBlocked);
 
 export const shouldDownloadPhotos = (photos) => {
   const downloadedPhotos = photos.filter(photoHasDownload);
   const stalePhotos = photos.filter(isPhotoStale);
-  const blockedPhotos = filterBlockedPhotos(photos);
+  const blockedPhotos = photos.filter(photoIsBlocked);
 
   const freshPercentage =
-    100 * (downloadedPhotos.length - blockedPhotos.length - stalePhotos.length) / downloadedPhotos.length;
+    100 * ((downloadedPhotos.length - blockedPhotos.length - stalePhotos.length) / downloadedPhotos.length);
 
-  const needsFreshPhotos = freshPercentage < MINIMINUM_FRESH_PERCENTAGE;
+  const needsFreshPhotos = freshPercentage < MIN_FRESH_PERCENTAGE;
   const isUnderMaxTotalDownload = downloadedPhotos.length < MAX_TOTAL_DOWNLOADED;
 
   return needsFreshPhotos || isUnderMaxTotalDownload;
@@ -38,10 +38,6 @@ export const markPhotoAsSeen = (photo: Photo & WithSeenCount) => {
   photo.seenCount = (photo.seenCount || 0) + 1;
   return photo;
 };
-
-export function filterBlockedPhotos<T extends Photo>(photos: T[]) {
-  return photos.filter((photo) => !photo.isBlocked);
-}
 
 export const markPhotoAsBlocked = (photo: Photo) => {
   photo.isBlocked = true;

--- a/src/photo-manager/photos.ts
+++ b/src/photo-manager/photos.ts
@@ -6,8 +6,10 @@ const MAX_TOTAL_DOWNLOADED = 20;
 const MIN_FRESH_PERCENTAGE = 25;
 
 export function photoHasDownload<T>(photo: T): photo is T & WithOptionalBlob {
-  if (typeof photo === 'object' && photo && 'blob' in photo && photo.blob instanceof Blob) {
-    return true;
+  if (typeof photo === 'object' && 'blob' in photo) {
+    // once `typescript` is updated this eslint ignore can be removed
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (photo as any).blob instanceof Blob;
   }
 
   return false;

--- a/src/photo-manager/photos.ts
+++ b/src/photo-manager/photos.ts
@@ -1,11 +1,11 @@
 import { photoStorage } from "../state/storage/photo";
-import type { Photo, WithBlob, WithSearchTerms, WithSeenCount } from "./types";
+import type { Photo, WithOptionalBlob, WithSearchTerms, WithSeenCount } from "./types";
 
 const STALE_SEEN_COUNT = 3;
 const MAX_TOTAL_DOWNLOADED = 20;
 const MIN_FRESH_PERCENTAGE = 25;
 
-export function photoHasDownload<T>(photo: T): photo is T & WithBlob {
+export function photoHasDownload<T>(photo: T): photo is T & WithOptionalBlob {
   if (typeof photo === 'object' && photo && 'blob' in photo && photo.blob instanceof Blob) {
     return true;
   }
@@ -13,7 +13,7 @@ export function photoHasDownload<T>(photo: T): photo is T & WithBlob {
   return false;
 }
 
-export const isPhotoStale = (photo: Photo & WithBlob & WithSeenCount) => photo.blob && photo.seenCount > STALE_SEEN_COUNT;
+export const isPhotoStale = (photo: Photo & WithOptionalBlob & WithSeenCount) => photo.blob && photo.seenCount > STALE_SEEN_COUNT;
 export const photoIsBlocked = (photo: Photo) => Boolean(photo.isBlocked);
 
 export const shouldDownloadPhotos = (photos) => {

--- a/src/photo-manager/replenisher.ts
+++ b/src/photo-manager/replenisher.ts
@@ -1,4 +1,4 @@
-import { fetchPhotos, query, resizePhoto } from "./fetch";
+import { fetchPhotosBlobs, query, resizePhoto } from "./fetch";
 import { retrieveAllPhotos as retrieveStoredPhotos, storePhoto } from "./photos";
 import shuffle from "./shuffle";
 import { take } from 'ramda';
@@ -27,7 +27,7 @@ export class Replenisher {
     const ineligiblePhotoIds = [...storedPhotos.map(photo => photo.id), ...this.downloadedPhotoIds];
     const eligiblePhotos = photoResults.filter(photo => !ineligiblePhotoIds.includes(photo.id));
     const downloadBatch = take(this.downloadBatchSize)(shuffle(eligiblePhotos));
-    return fetchPhotos(downloadBatch);
+    return fetchPhotosBlobs(downloadBatch);
   }
 
   async resizeBatch(batch) {

--- a/src/photo-manager/replenisher.ts
+++ b/src/photo-manager/replenisher.ts
@@ -6,7 +6,7 @@ import { take } from 'ramda';
 export class Replenisher {
   batchesFetched = 0;
   downloadBatchSize = 2;
-  maxBatches = 2;
+  maxBatches = 4;
 
   searchTerms: string;
 

--- a/src/photo-manager/types.ts
+++ b/src/photo-manager/types.ts
@@ -8,8 +8,8 @@ export type WithSearchTerms = {
   searchTerms: string;
 }
 
-export type WithBlob = {
-  blob: Blob;
+export type WithOptionalBlob = {
+  blob: Blob | undefined;
 }
 
 export type WithSeenCount = {

--- a/src/photo-manager/types.ts
+++ b/src/photo-manager/types.ts
@@ -1,0 +1,17 @@
+export type Photo = {
+  id: string;
+  url_o: string;
+  isBlocked: boolean;
+};
+
+export type WithSearchTerms = {
+  searchTerms: string;
+}
+
+export type WithBlob = {
+  blob: Blob;
+}
+
+export type WithSeenCount = {
+  seenCount?: number;
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,8 +5,14 @@
   import { onMount } from 'svelte';
   import { afterNavigate } from '$app/navigation';
   import { handleInitialHashRoute, handleRouteChange } from '../helpers/hash-routes';
+  import Debug from 'debug';
 
   export const prerender = true
+
+  // Enable all debug logging for the entire app
+  if (globalThis?.localStorage) {
+    window.localStorage.debug = '*'
+  }
 
   onMount(async () => {
     const [teardownPhotoStore] = await Promise.all([

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,10 +18,6 @@
     return () => teardownPhotoStore();
   });
 
-  $: {
-    console.log('currentPhoto', $currentPhoto);
-  }
-
   afterNavigate(() => {
     handleRouteChange();
   });
@@ -29,7 +25,8 @@
 
 <div class="shell">
   <slot />
-  {#if $currentPhoto.photo?.blob}
+
+  {#if $currentPhoto.photo?.blob && !$currentPhoto.photo.isBlocked}
     <Wallpaper blur={$currentPhoto.blur} photoUrl={URL.createObjectURL($currentPhoto.photo.blob)} />
   {/if}
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,9 +15,12 @@
     ]);
 
     await performPhotoHouseKeeping();
-
     return () => teardownPhotoStore();
   });
+
+  $: {
+    console.log('currentPhoto', $currentPhoto);
+  }
 
   afterNavigate(() => {
     handleRouteChange();
@@ -26,8 +29,8 @@
 
 <div class="shell">
   <slot />
-  {#if $currentPhoto.url}
-    <Wallpaper blur={$currentPhoto.blur} photoUrl={$currentPhoto.url} />
+  {#if $currentPhoto.photo?.blob}
+    <Wallpaper blur={$currentPhoto.blur} photoUrl={URL.createObjectURL($currentPhoto.photo.blob)} />
   {/if}
 </div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,16 +2,16 @@
   import CountdownTimer from '../components/CountdownTimer.svelte';
   import CountdownMessage from '../components/CountdownMessage.svelte';
   import SettingsButton from '../components/SettingsButton.svelte';
+  import BlockButton from '../components/BlockButton.svelte';
   import { getSettingsStore } from '../state/stores/settings';
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
+  import { currentPhoto, blockPhoto } from '../state/stores/photo';
 
-  let settingsStore;
-  $: storeLoaded = false;
+  $: settingsStore = null;
 
   onMount(async () => {
     settingsStore = await getSettingsStore();
-    storeLoaded = true;
   });
 
   function goToSettings() {
@@ -23,7 +23,13 @@
   <SettingsButton onClick={goToSettings} />
 </div>
 
-{#if storeLoaded}
+{#if $currentPhoto.photo}
+  <div class="Index__BlockButton">
+    <BlockButton onClick={() => blockPhoto($currentPhoto.photo)}/>
+  </div>
+{/if}
+
+{#if settingsStore}
   <CountdownMessage
     endDate={$settingsStore.date}
     countdownMessage={$settingsStore.countdownMessage}
@@ -42,10 +48,21 @@
     position: fixed;
     top: 1.2rem;
     right: 1.2rem;
+    padding: 0;
   }
 
   .Index__SettingsButton:hover {
     /* HOVER OPACITY */
     opacity: 1;
+  }
+
+  .Index__BlockButton {
+    /* INITIAL OPACITY */
+    opacity: 0.75;
+
+    display: block;
+    position: fixed;
+    bottom: 1.2rem;
+    right: 1.2rem;
   }
 </style>

--- a/src/state/storage/photo.ts
+++ b/src/state/storage/photo.ts
@@ -1,0 +1,3 @@
+import { SimpleIndexedDbAdapter } from "./SimpleIndexedDbAdapter";
+
+export const photoStorage = new SimpleIndexedDbAdapter('VORFREUDE_PHOTO_STORAGE');

--- a/src/state/stores/photo.ts
+++ b/src/state/stores/photo.ts
@@ -35,7 +35,7 @@ export async function performPhotoHouseKeeping() {
     throw new Error('Store must be setup first, ensure `setup` has been called');
   }
 
-  if (isBrowser) {
+  if (isBrowser && await manager.shouldReplenishBacklog()) {
     await manager.startReplenishBacklog();
     await Promise.all([manager.removeStalePhotoBlobs(), manager.removeOldPhotos()]);
   }

--- a/src/state/stores/photo.ts
+++ b/src/state/stores/photo.ts
@@ -1,4 +1,4 @@
-import type { Photo, WithBlob } from 'src/photo-manager/types';
+import type { Photo, WithOptionalBlob } from 'src/photo-manager/types';
 import { writable } from 'svelte/store';
 import Manager from '../../photo-manager/manager';
 import { getSettingsStore } from './settings';
@@ -6,7 +6,7 @@ import { getSettingsStore } from './settings';
 const isBrowser = typeof window !== 'undefined';
 let manager: Manager;
 
-export const currentPhoto = writable<{ blur: boolean; photo?: Photo & WithBlob }>(
+export const currentPhoto = writable<{ blur: boolean; photo?: Photo & WithOptionalBlob }>(
   { blur: false, photo: undefined }
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,6 +1982,13 @@
   resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.6.tgz#f830323c88172e66826d0bde413498b61054b5a6"
   integrity sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==
 
+"@types/ramda@^0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.29.0.tgz#4f226db24764dde77c60e1f601c357894bcfb7cc"
+  integrity sha512-TY9eKsklU43CmAbFJPKDUyBjleZ4EFAkbJeQRF4e8byGkOw1CjDcwg5EGa0Bgf0Kgs9BE9OU4UzQWnQDHnvMtA==
+  dependencies:
+    types-ramda "^0.29.1"
+
 "@types/resolve@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
@@ -5812,6 +5819,11 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
+ts-toolbelt@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
+  integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -5857,6 +5869,13 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+types-ramda@^0.29.1:
+  version "0.29.1"
+  resolved "https://registry.yarnpkg.com/types-ramda/-/types-ramda-0.29.1.tgz#08c6ddf583ba359ec1113c7069e30a44ef73896d"
+  integrity sha512-pdEF8VXcBTSu3fPupZahieG6Lh8eBWPtcaH/OB5QPCoN2hz4vBbspoMLB3X9kwzXRD3lwD4/j0hwj3Z/PAzzcA==
+  dependencies:
+    ts-toolbelt "^9.6.0"
 
 typescript@*:
   version "4.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,6 +1892,13 @@
     "@types/filesystem" "*"
     "@types/har-format" "*"
 
+"@types/debug@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/estree@*":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
@@ -1966,6 +1973,11 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.0.1.tgz#2b1657096473e24b049bdedf3710f99645f3a17f"
   integrity sha512-/LAvk1cMOJt0ghzMFrZEvByUhsiEfeeT2IF53Le+Ki3A538yEL9pRZ7a6MuCxdrYK+YNqNIDmrKU/r2nnw04zQ==
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*":
   version "17.0.21"


### PR DESCRIPTION
This pull request adds the ability to block photos from being seen. This is useful because sometimes the randomly chosen photos from flickr are not suitable for many reasons (inappropriate, irrelevant, just random). Once the background has been blocked a new one is loaded as soon as a photo candidate is available. The photo is tagged with an `isBlocked` flag and its `blob` is removed.

_See bottom right block icon (in the future this should also have a tooltip, see #56)_
<img width="932" alt="image" src="https://github.com/chadian/vorfreude/assets/2770198/8f37accb-ac40-49ca-869d-1aec122a0724">

## TODO
- [X] Clear out current photo immediately while the other one loads
- [x] Improve test coverage
- [x] Compare start up performance between changes in the PR and `master`