### PR TITLE
Fix background types

### DIFF
--- a/.github/workflows/yarn-test.yml
+++ b/.github/workflows/yarn-test.yml
@@ -15,3 +15,9 @@ jobs:
       - run: yarn playwright install
       - run: yarn lint
       - run: yarn test
+      - run: |
+          echo "Testing build..."
+          yarn build
+      - run: |
+          echo "Testing package..."
+          yarn package

--- a/src/photo-manager/fetch.ts
+++ b/src/photo-manager/fetch.ts
@@ -1,7 +1,7 @@
 import { clone } from 'ramda';
 import { highQualityImageUrlForPhoto } from './photos';
 import resizePhotoBlob from './resizePhoto';
-import type { Photo, WithOptionalBlob, WithSearchTerms } from './types';
+import type { Photo, WithOptionalBlob, WithSearchTerms } from 'src/state/stores/photo';
 
 export const IMAGE_ENDPOINT_API_URL = 'https://web-production-be97.up.railway.app/api/images';
 

--- a/src/photo-manager/manager.ts
+++ b/src/photo-manager/manager.ts
@@ -15,9 +15,9 @@ import { cleanDownloadFromPhoto, cleanUnblockedPhotosWithoutGivenSearchTerms } f
 import shuffle from './shuffle';
 import isExtensionEnv from '../helpers/isExtensionEnv';
 import { Replenisher } from './replenisher';
-import type { Photo, WithOptionalBlob, WithSeenCount } from './types';
 import { BackgroundOperation } from '../background-operation';
 import Debug from 'debug';
+import type { Photo, WithSeenCount, WithOptionalBlob } from 'src/state/stores/photo';
 
 const DOWNLOAD_BATCH_SIZE = 3;
 const DELETE_STALE_BATCH_SIZE = 3;

--- a/src/photo-manager/photos.ts
+++ b/src/photo-manager/photos.ts
@@ -1,4 +1,9 @@
-import type { WithOptionalBlob, Photo, WithSeenCount, WithSearchTerms } from 'src/state/stores/photo';
+import type {
+  WithOptionalBlob,
+  Photo,
+  WithSeenCount,
+  WithSearchTerms
+} from 'src/state/stores/photo';
 import { photoStorage } from '../state/storage/photo';
 
 const STALE_SEEN_COUNT = 3;

--- a/src/photo-manager/photos.ts
+++ b/src/photo-manager/photos.ts
@@ -1,5 +1,5 @@
+import type { WithOptionalBlob, Photo, WithSeenCount, WithSearchTerms } from 'src/state/stores/photo';
 import { photoStorage } from '../state/storage/photo';
-import type { Photo, WithOptionalBlob, WithSearchTerms, WithSeenCount } from './types';
 
 const STALE_SEEN_COUNT = 3;
 const MAX_TOTAL_DOWNLOADED = 20;


### PR DESCRIPTION
In going to release v0.4.5 it was discovered that the previous pr left the type imports in a bad state. While this didn't impact the svelte build it did impact the build for the background script that uses rollup.

This pull request:
* fixes the type imports
* adds a test build and test package commands to CI to ensure these aren't broken either in future branches